### PR TITLE
Fix Elasticsearch _msearch Timeout Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Add the following configuration block to your `mcpServers` object:
         "ES_PASSWORD": "YOUR_ELASTICSEARCH_PASSWORD",
       },
       "alwaysAllow": [],
+      "timeout": 120,
       "disabled": false
     }
 ```

--- a/src/es_knowledge_base_mcp/clients/es_knowledge_base.py
+++ b/src/es_knowledge_base_mcp/clients/es_knowledge_base.py
@@ -6,9 +6,8 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from elastic_transport import ObjectApiResponse
 from elasticsearch import (
     ApiError,
     AsyncElasticsearch,
@@ -44,6 +43,9 @@ from es_knowledge_base_mcp.interfaces.knowledge_base import (
 )
 from es_knowledge_base_mcp.models.constants import CRAWLER_INDEX_MAPPING
 from es_knowledge_base_mcp.models.settings import KnowledgeBaseServerSettings
+
+if TYPE_CHECKING:
+    from elastic_transport import ObjectApiResponse
 
 logger = get_logger("knowledge-base-mcp.elasticsearch")
 

--- a/src/es_knowledge_base_mcp/clients/es_knowledge_base.py
+++ b/src/es_knowledge_base_mcp/clients/es_knowledge_base.py
@@ -1,5 +1,6 @@
 """Elasticsearch client for managing and searching knowledge bases."""
 
+import asyncio
 import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -7,6 +8,7 @@ from copy import deepcopy
 from datetime import UTC, datetime
 from typing import Any
 
+from elastic_transport import ObjectApiResponse
 from elasticsearch import (
     ApiError,
     AsyncElasticsearch,
@@ -47,10 +49,7 @@ logger = get_logger("knowledge-base-mcp.elasticsearch")
 
 # endregion Index Handling
 
-
 logger = get_logger("knowledge-base-mcp.knowledge-base")
-
-HITS_CACHE_BUST_INTERVAL = 60  # seconds
 
 
 class ElasticsearchError(KnowledgeBaseError):
@@ -94,8 +93,6 @@ class ElasticsearchKnowledgeBaseClient(KnowledgeBaseClient):
         self.index_pattern = settings.base_index_pattern
 
         self.elasticsearch_client = elasticsearch_client
-
-        self._last_cache_bust = datetime.now(tz=UTC)
 
     # region Error Handling
 
@@ -424,13 +421,33 @@ class ElasticsearchKnowledgeBaseClient(KnowledgeBaseClient):
                 )
             )
 
-        async with self.error_handler("multi-search operation"):
-            msearch_results = await self.elasticsearch_client.options(retry_on_timeout=True).msearch(searches=operations)
+        msearch_results: ObjectApiResponse | None = None
+
+        for i in range(3):
+            async with self.error_handler("multi-search operation"):
+                msearch_results = await self.elasticsearch_client.options(retry_on_timeout=True).msearch(searches=operations)
+
+            if not msearch_results or "responses" not in msearch_results:
+                msg = f"No results returned from multi-search operation {msearch_results}. Retrying... ({i + 1}/3)"
+                logger.warning(msg)
+                continue
+
+            if any(response.get("status") == 408 for response in msearch_results["responses"]):  # noqa: PLR2004
+                msg = f"One or more responses returned a 408 status {msearch_results}. Sleeping for 30 seconds and retrying... ({i + 1}/3)"
+                logger.warning(msg)
+                await asyncio.sleep(30)
+                continue
+
+            if any(response.get("status") != 200 for response in msearch_results["responses"]):  # noqa: PLR2004
+                msg = f"One or more responses returned a non-200 status {msearch_results}. Retrying... ({i + 1}/3)"
+                logger.warning(msg)
+                continue
+
+            break
 
         if not msearch_results or "responses" not in msearch_results:
-            msg = "No results returned from multi-search operation."
-            logger.warning(msg)
-            return []
+            msg = "No response returned from multi-search operation."
+            raise KnowledgeBaseSearchError(msg)
 
         search_results: list[KnowledgeBaseSearchResultTypes] = []
 
@@ -438,10 +455,9 @@ class ElasticsearchKnowledgeBaseClient(KnowledgeBaseClient):
             phrase = phrases[i]
 
             if not response.get("hits", {}).get("hits"):
-                error_message = "No hits found in one of the search responses."
+                error_message = f"No hits found in one of the search responses. {response}"
                 search_results.append(KnowledgeBaseSearchResultError(phrase=phrase, error=error_message))
                 logger.warning(error_message)
-                logger.warning(response)
                 continue
 
             summaries: list[PerKnowledgeBaseSummary] = [

--- a/src/es_knowledge_base_mcp/models/settings.py
+++ b/src/es_knowledge_base_mcp/models/settings.py
@@ -47,6 +47,8 @@ class LoggingSettings(BaseSettings):
         """Configure logging based on the settings."""
         logging.basicConfig(level=self.log_level, format=self.log_format, filename=self.log_file, filemode="a", force=True)
 
+        logging.getLogger("mcp").setLevel("WARNING")
+
         return logger
 
 


### PR DESCRIPTION
Elasticsearch will return a 200 error for an `_msearch` where all underlying searches fail. So we cannot rely on SDK based retries for `_msearch`.

Implement custom retry logic and add a 30s wait when we encounter a 408 (ML model is not ready).